### PR TITLE
Missing Rate Limiting vulnerability fix (powered by Mobb)

### DIFF
--- a/web_server/package.json
+++ b/web_server/package.json
@@ -30,6 +30,7 @@
     "ejs": "^3.1.7",
     "escape-string-regexp": "^1.0.5",
     "express": "^4.16.4",
+    "express-rate-limit": ">=7.4.0",
     "express-session": "^1.17.1",
     "jquery": "^3.3.1",
     "mongoose": "^6.2.5",

--- a/web_server/routes/core.js
+++ b/web_server/routes/core.js
@@ -12,6 +12,7 @@
  * governing permissions and limitations under the License.
  */
 
+const rateLimit = require('express-rate-limit');
 const express = require('express');
 const router = express.Router();
 
@@ -98,7 +99,7 @@ module.exports = function (envConfig) {
         res.render('pages/help', params);
     });
 
-    router.get('/ip', function (req, res) {
+    router.get('/ip', rateLimit({ limit: 60 }), function (req, res) {
         setHeaders(res);
         let params = getSessionParams(req);
         res.render('pages/ip', params);


### PR DESCRIPTION
This change fixes a **medium severity** (🟡) **Missing Rate Limiting** issue reported by **Snyk**.

## Issue description
The lack of a rate limit can allow denial-of-service attacks, in which an attacker can cause the application to crash or become unresponsive by issuing a large number of requests simultaneously.
 
## Fix instructions
Use express-rate-limit npm package to set a rate limit.

## Additional actions required
 We set the default limit to 60 requests per minute. To customize the rate limit settings, please read the documentation of the [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) package.


[More info and fix customization are available in the Mobb platform](https://app.mobb.ai/organization/3922115b-936a-4876-a8fd-4d6c62d19d7d/project/ab7b6c59-ce4f-487a-947d-6fccb960ad03/report/e263f478-cd1b-403e-acad-22c029361bec/fix/0d0b26cb-e4b4-4d63-8170-49109fc66057)